### PR TITLE
AVR only - add optional pwmMode constructor variable, add methods to set and get PWM frequency when using timer based PWM generation

### DIFF
--- a/FanController.h
+++ b/FanController.h
@@ -7,22 +7,38 @@
 #define FanController_h
 
 #include "Arduino.h"
+#include "PWM.h"
 
 class FanController
 {
 	public:
-		FanController(byte sensorPin, unsigned int sensorThreshold, byte pwmPin = 0);
+		FanController(byte sensorPin, unsigned int sensorThreshold, byte pwmPin = 0, byte pwmMode = 0);
 		void begin();
 		unsigned int getSpeed();
 		void setDutyCycle(byte dutyCycle);
 		byte getDutyCycle();
+
+	#if defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__) || (__AVR_ATmega48__) || defined(__AVR_ATmega88__) || defined(__AVR_ATmega88P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
+		bool setPwmFrequency(int32_t freq);
+		int32_t getPwmFrequency();
+	#endif
+
+	enum pwmMode {           // PWM operation mode based on PWM.h created by https://code.google.com/archive/p/arduino-pwm-frequency-library/downloads, Arduino forums post: https://forum.arduino.cc/t/pwm-frequency-library/114988
+    	SW_PWM,              // Will use default Arduino pwm function, specifically analogWrite
+    	HW_PWM,              // Will use hardware based Timer driven fast PWM mode with additional option of setting the frequency 
+	};
+	
 	private:
 		static FanController *_instances[6];
 		byte _sensorPin;
 		byte _sensorInterruptPin;
 		unsigned int _sensorThreshold;
 		byte _pwmPin;
+		byte _pwmMode;
 		byte _pwmDutyCycle;
+		#if defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__) || (__AVR_ATmega48__) || defined(__AVR_ATmega88__) || defined(__AVR_ATmega88P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
+			int32_t _pwmFrequency;
+		#endif
 		byte _instance;
 		unsigned int _lastReading;
 		volatile unsigned int _halfRevs;

--- a/examples/Monitor and Control and Frequency AVR/MonitorAndControlandFreq.ino
+++ b/examples/Monitor and Control and Frequency AVR/MonitorAndControlandFreq.ino
@@ -1,0 +1,97 @@
+// Include the library
+#include <FanController.h>
+
+// Sensor wire is plugged into port 2 on the Arduino.
+// For a list of available pins on your board,
+// please refer to: https://www.arduino.cc/en/Reference/AttachInterrupt
+#define SENSOR_PIN 2
+
+// Choose a threshold in milliseconds between readings.
+// A smaller value will give more updated results,
+// while a higher value will give more accurate and smooth readings
+#define SENSOR_THRESHOLD 1000
+
+// PWM pin (4th on 4 pin fans)
+// It's possible to control 3 wire fans via. external mosfet, typically N-channel FET
+#define PWM_PIN 9
+
+// Frequnecy of PWM pin is avaliable for AVR platform, HW_PWM mode is set by additional constructor parameter
+// pwmMode: 0 - Using regular Arduino analogWrite, 1 - Using timer based fastPWM mode
+#define PWM_MODE 1
+
+// Initialize library
+FanController fan(SENSOR_PIN, SENSOR_THRESHOLD, PWM_PIN, PWM_MODE);
+
+/*
+   The setup function. We only start the library here
+*/
+void setup(void){
+  Serial.begin(9600);  // start serial port
+  uint32_t startMillis = millis();
+  while (!Serial && ((millis() - startMillis) < 3000) ) {
+  }
+  if (!Serial) {
+    // Serial port failed to initialize, take appropriate action
+  } else {
+    Serial.println("Fan Controller Library Demo");
+  }
+  // Start up the library
+  fan.begin();
+}
+
+
+/*
+  Main function, get and show fan speed, change PWM frequnecy to 25 kHz
+  Most 4pin / 4wire fans require PWM pulse at 25kHz freq. per their datasheets.
+  For 3pin / 3wire fans if connected via. external mosfet for speed control will benefit from PWM freq. above audiable range (Audibale range is 20Hz-20kHz) so 25 kHz will work great for that. 
+*/
+void loop(void)
+{
+  // Call fan.getSpeed() to get fan RPM.
+  Serial.print("Current speed: ");
+  unsigned int rpms = fan.getSpeed();      // Send the command to get RPM
+  Serial.print(rpms);
+  Serial.println("RPM");
+
+  if (fan.setPwmFrequency(25000)){         // Set PWM freq. to 25kHz
+    Serial.println("PWM Frequency Set");
+  }
+
+  // Get new speed from Serial (0-100%)
+  if (Serial.available() > 0) {
+    // Parse speed
+    int input = Serial.parseInt();
+
+    // Constrain a 0-100 range
+    byte target = max(min(input, 100), 0);
+
+    // Print obtained value
+    Serial.print("Setting duty cycle: ");
+    Serial.println(target, DEC);
+
+    // Set fan duty cycle
+    fan.setDutyCycle(target);
+
+    // Get duty cycle
+    byte dutyCycle = fan.getDutyCycle();
+    Serial.print("Duty cycle: ");
+    Serial.println(dutyCycle, DEC);
+
+    // Get PWM Mode
+    if (!_pwmMode){
+      Serial.println("Standard Arduino PWM Mode");
+    }
+    else if (_pwmMode == 1){
+      Serial.println("Timer Based PWM Mode");
+    }
+
+    // Get PWM freq.
+    int32_t pwmFreq = fan.getPwmFrequency();
+    Serial.print("PWM Freq. Set [Hz]: ");
+    Serial.println(pwmFreq);
+  }
+
+  // Not really needed, just avoiding spamming the monitor,
+  // readings will be performed no faster than once every THRESHOLD ms anyway
+  delay(250);
+}


### PR DESCRIPTION
All credit goes to Sam Knight for his FastPWM library - PWM.h
https://code.google.com/archive/p/arduino-pwm-frequency-library/downloads
https://forum.arduino.cc/t/pwm-frequency-library/114988
https://github.com/RCS101/PWM

Changes summary:

1. All changes are for AVR platform only.
2. Added pwmMode constructor variable, 0 - Arduino native PWM, 1 - Timer based Fast PWM with option to change frequency.
3. Added get / set methods for frequency, units are Hz.
`bool FanController::setPwmFrequency(int32_t freq)`
`int32_t FanController::getPwmFrequency()`
4. Added example arduino sketch.