### PR TITLE
Updated FanController.cpp for ESP32

### DIFF
--- a/FanController.cpp
+++ b/FanController.cpp
@@ -50,7 +50,7 @@ unsigned int FanController::getSpeed() {
 	return _lastReading;
 }
 
-void FanController::setDutyCycle(byte dutyCycle) {}
+void FanController::setDutyCycle(byte dutyCycle) {
     _pwmDutyCycle = min((int)dutyCycle, 100); // _pwmDutyCycle is 0-100
 
 #if defined(ARDUINO_ARCH_ESP32)

--- a/FanController.cpp
+++ b/FanController.cpp
@@ -26,8 +26,9 @@ void FanController::begin()
 	_instance = instance;
 	_instances[instance] = this;
 #if defined(ARDUINO_ARCH_ESP32)
-	analogWriteResolution(_pwmPin, 9);
-	analogWriteFrequency(_pwmPin, (uint32_t)25000);
+	// analogWriteResolution(_pwmPin, 9);//changed this - GR
+	analogWriteResolution(9);
+	analogWriteFrequency((uint32_t)25000);
 #endif
 	digitalWrite(_sensorPin, HIGH);
 	setDutyCycle(_pwmDutyCycle);
@@ -49,9 +50,18 @@ unsigned int FanController::getSpeed() {
 	return _lastReading;
 }
 
-void FanController::setDutyCycle(byte dutyCycle) {
-	_pwmDutyCycle = min((int)dutyCycle, 100);
-	analogWrite(_pwmPin, (int)(2.55 * _pwmDutyCycle));
+void FanController::setDutyCycle(byte dutyCycle) {}
+    _pwmDutyCycle = min((int)dutyCycle, 100); // _pwmDutyCycle is 0-100
+
+#if defined(ARDUINO_ARCH_ESP32)
+    // ESP32 is configured for 9-bit resolution (0-511) in begin()
+    const int maxPwmValue = 511; // (1 << 9) - 1
+    analogWrite(_pwmPin, (int)((_pwmDutyCycle / 100.0) * maxPwmValue));
+#else
+    // Standard Arduino (AVR - typically 8-bit PWM, 0-255)
+    // The original 2.55 scaling factor is for 8-bit
+    analogWrite(_pwmPin, (int)(2.55 * _pwmDutyCycle)); // Equivalent to ((_pwmDutyCycle / 100.0) * 255.0)
+#endif
 }
 
 byte FanController::getDutyCycle() {


### PR DESCRIPTION
Fixed setDutyCycle() and begin() methods to properly implement 9 bit analog resolution for ESP32. Functionality unchanged if using Arduino. Previous version had a syntax error that prevented compile using a standard config of Platformio with ESP32. If previous was intended, please let me know, but this update feels more user friendly.